### PR TITLE
Fixes length issues, capital alignment issues, author name overlap issue

### DIFF
--- a/bookshelf.css
+++ b/bookshelf.css
@@ -134,12 +134,14 @@
     color: gold;
     writing-mode: vertical-rl;
     text-orientation: mixed;
+    /* Adding a bottom padding so that it does not mess with the author name */
+    padding-bottom: 15px;
   }
   
   .spine-author {
     position: absolute;
     color: goldenrod;
-    bottom: 0px;
+    bottom: 0px;  
     left: 20%; /* no idea why 20% centers it */
   }
   

--- a/bookshelf.css
+++ b/bookshelf.css
@@ -136,6 +136,7 @@
     text-orientation: mixed;
     /* Adding a bottom padding so that it does not mess with the author name */
     padding-bottom: 15px;
+    text-transform: capitalize;
   }
   
   .spine-author {

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -45,11 +45,4 @@ spines.map(function (s, i) {
   if (titles[i].innerHTML.length > 75) {
     titles[i].innerHTML = titles[i].innerHTML.substring(0, 73) + "...";
   }
-
-  //If all caps capitalize the first letter of each word as all capitals also spoil the alignment
-  if (titles[i].innerHTML.toUpperCase() === titles[i].innerHTML) {
-    titles[i].innerHTML = titles[i].innerHTML.replace(/\w\S*/g, function (txt) {
-      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-    });
-  }
 });

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -11,8 +11,9 @@ function randomChoice(array) {
 let spines = Object.values(document.getElementsByClassName("spine"));
 let covers = Object.values(document.getElementsByClassName("cover"));
 let tops = Object.values(document.getElementsByClassName("top"));
+let titles = Object.values(document.getElementsByClassName("spine-title"));
 
-let availablePatterns = ["argyle", "tartan"]; // we could probably get these programatically
+let availablePatterns = ["argyle", "tartan"]; // we could probably get these programmatically
 let availableColours = [
   "maroon",
   "darkgreen",
@@ -39,4 +40,15 @@ spines.map(function (s, i) {
   covers[i].style.top = `${280 - randomHeight}px`;
 
   tops[i].style.top = `${280 - randomHeight}px`;
+
+  // 75 characters above spoils the alignment
+  if(titles[i].innerHTML.length > 75) {
+    titles[i].innerHTML = titles[i].innerHTML.substring(0, 73) + "...";
+  }
+
+  // capitalize the first letter of each word as all capitals also spoil the alignment
+  titles[i].innerHTML = titles[i].innerHTML.replace(/\w\S*/g, function(txt){
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  }
+  );
 });

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -42,13 +42,14 @@ spines.map(function (s, i) {
   tops[i].style.top = `${280 - randomHeight}px`;
 
   // 75 characters above spoils the alignment
-  if(titles[i].innerHTML.length > 75) {
+  if (titles[i].innerHTML.length > 75) {
     titles[i].innerHTML = titles[i].innerHTML.substring(0, 73) + "...";
   }
 
-  // capitalize the first letter of each word as all capitals also spoil the alignment
-  titles[i].innerHTML = titles[i].innerHTML.replace(/\w\S*/g, function(txt){
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  //If all caps capitalize the first letter of each word as all capitals also spoil the alignment
+  if (titles[i].innerHTML.toUpperCase() === titles[i].innerHTML) {
+    titles[i].innerHTML = titles[i].innerHTML.replace(/\w\S*/g, function (txt) {
+      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    });
   }
-  );
 });


### PR DESCRIPTION
From trial and error characters over 75 often caused alignment issues. To fix this a truncation was introduced at the cost of the title.

All caps titles also caused alignment issues. To fix this only the first letter of the word was capitalized.

Often with big titles it often used to overlap with the author name. To fix this a small padding to remove overlap has been introduced. 