### PR TITLE
Fix: Title length issue and overlap with author

### DIFF
--- a/bookshelf.js
+++ b/bookshelf.js
@@ -8,6 +8,14 @@ function randomChoice(array) {
   return array[Math.floor(Math.random() * array.length)];
 }
 
+function adjustTextStyle(length) {
+  if (length > 150) return [true, "9.5px", "23px"];
+  if (length > 100) return [true, "10px", "22px"];
+  if (length > 95) return [true, "10.5px", "21px"];
+  if (length > 84) return [true, "11px", "20px"];
+  return [false, "0px", "0px"];
+}
+
 let spines = Object.values(document.getElementsByClassName("spine"));
 let covers = Object.values(document.getElementsByClassName("cover"));
 let tops = Object.values(document.getElementsByClassName("top"));
@@ -25,7 +33,16 @@ let availableColours = [
 
 // assign a random height, pattern and colour to each book
 spines.map(function (s, i) {
-  let randomHeight = getRandomInt(220, 290);
+  const spineTitle = s.firstElementChild;
+  const titleLength = [...spineTitle.textContent].length;
+  const [adjustmentNeeded, fontSize, paddingBottom] = adjustTextStyle(titleLength);
+  const randomHeight = adjustmentNeeded ? getRandomInt(270, 290) : getRandomInt(220, 290);
+
+  if (adjustmentNeeded) {
+    spineTitle.style.fontSize = fontSize;
+    spineTitle.style.paddingBottom = paddingBottom;
+  }
+
   s.style.height = `${randomHeight}px`;
   s.style.top = `${280 - randomHeight}px`;
 


### PR DESCRIPTION
I really liked this project (well done by the way!) and wanted to work on the title issue. 

My goal was to allow up to 220 character-long titles, without overflowing the parent container or overlapping with the author's initials. Of course, this can further be adjusted to accommodate even longer titles.

The approach is a JS/CSS combination, by dynamically adjusting the font size, adding a little bit of padding at the bottom, and evaluating the min/max spine height accordingly. 

Looking forward to hearing your thoughts!