### PR TITLE
feat: Lazy-loading of book covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Virtual Bookshelf
 This is a simple visualisation of books on a bookshelf using some CSS transforms to give the effect of picking out the book when you hover over it.
 
-I use it on my [personal site](https://petargyurov.com) to track what books I've read. It integrates nicely with static site generators, and well, just about anything since it's all vanilla JS, CSS and HTML.
+It integrates nicely with static site generators, and well, just about anything since it's all vanilla JS, CSS and HTML. Have a look at the [examples](#examples) below!
 
 ![Example](https://i.imgur.com/6u0CySS.png)
 
@@ -15,7 +15,10 @@ A book is defined as follows:
         <span class="spine-author"> PG </span>
     </div>
     <div class="side top"></div>
-    <div class="side cover"></div>
+    <div 
+        class="side cover"
+        img="https://picsum.photos/190/280"
+    />
 </div>
 ```
 
@@ -35,3 +38,8 @@ If you found this project useful you can make use of the following badge to spre
 **Is it perfect?**
 
 Nope. Doesn't handle long titles well. I'm sure there are other alignment issues. I wrote this in a day, don't expect much. Feel free to submit fixes/improvements.
+
+## Examples
+
+- [petargyurov.com](https://petargyurov.com/bookshelf)
+- [janehndrikewers.uk](https://janhendrikewers.uk/bookshelf)

--- a/bookshelf.css
+++ b/bookshelf.css
@@ -196,7 +196,7 @@
     width: 190px;
     height: 280px;
     top: 0px;
-    background-image: url("https://picsum.photos/190/280");
+    background-color: grey;
     background-size: contain;
     background-repeat: round;
     left: 50px;

--- a/bookshelf.js
+++ b/bookshelf.js
@@ -43,3 +43,15 @@ spines.map(function (s, i) {
 
   tops[i].style.top = `${280 - randomHeight}px`;
 });
+//
+// lazy load the book covers on hover
+let books = Object.values(document.getElementsByClassName("book"));
+books.map(function (b, i) {
+  b.onmouseover = function () {
+    let covers = b.getElementsByClassName("cover");
+    Array.from(covers).map(function (c, i) {
+      c.style.backgroundImage = "url(" + c.getAttribute("img") + ")";
+    }
+    )
+  };
+});

--- a/index.html
+++ b/index.html
@@ -12,7 +12,10 @@
           <span class="spine-author"> PG </span>
         </div>
         <div class="side top"></div>
-        <div class="side cover"></div>
+        <div 
+            class="side cover"
+            img="https://picsum.photos/190/280"
+            />
       </div>
     </div>
   </body>


### PR DESCRIPTION
My bookshelf has grown to over 40 books now which was getting very expensive on each new load. This new feature does introduce some lag when hovering but the trade-off is worth it. 

If this was used within jekyll for example, one could disable this for the most recent year and enable for older entries.